### PR TITLE
include loader and virtual in npm package

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -25,6 +25,8 @@
   },
   "files": [
     "dist",
+    "loader.js",
+    "zero-virtual.css",
     "package.json"
   ]
 }


### PR DESCRIPTION
I got an error "[Error] cannot find module ../loader.js" after testing the published package with Nextjs.