### PR TITLE
[sx] Fix sx vars presedence

### DIFF
--- a/packages/runtime/src/styled.jsx
+++ b/packages/runtime/src/styled.jsx
@@ -135,8 +135,8 @@ export default function styled(tag, options = {}) {
           ref={ref}
           className={finalClassName}
           style={{
-            ...style,
             ...varStyles,
+            ...style,
           }}
         />
       );
@@ -149,8 +149,8 @@ export default function styled(tag, options = {}) {
         ref={ref}
         className={finalClassName}
         style={{
-          ...style,
           ...varStyles,
+          ...style,
         }}
       />
     );


### PR DESCRIPTION
If a var is defined in the style prop it must have biggest presedence.