### PR TITLE
[styled] Fix variant's props callback arg

### DIFF
--- a/packages/runtime/src/styled.jsx
+++ b/packages/runtime/src/styled.jsx
@@ -6,8 +6,7 @@ function getVariantClasses(componentProps, variants) {
   const variantClasses = variants
     .filter(({ props: variantProps }) =>
       typeof variantProps === 'function'
-        ? variantProps(componentProps.ownerState) ||
-          variantProps(componentProps)
+        ? variantProps({ ...componentProps, ...componentProps.ownerState })
         : Object.entries(variantProps).every(([propKey, propValue]) => {
             return (
               ownerState[propKey] === propValue ||


### PR DESCRIPTION
I noticed this bug while working on the Badge component. If people access ownerState with some nested object, it could be undefined when the callback is invoked with the ownerState directly. The correct solution would be to merge the props with ownerState - this way people can interchangeably use props and ownerState.